### PR TITLE
Feature/6/querydsl JPA Querydsl 테스트

### DIFF
--- a/guestbook/build.gradle
+++ b/guestbook/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'war'
+	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'org.zerock'
@@ -31,8 +32,29 @@ dependencies {
 	compile group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.7.1'
 	compile group: 'org.thymeleaf.extras', name: 'thymeleaf-extras-java8time'
 
+	implementation 'com.querydsl:querydsl-jpa'
+
 }
 
 test {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/guestbook/src/main/java/org/zerock/guestbook/entity/Guestbook.java
+++ b/guestbook/src/main/java/org/zerock/guestbook/entity/Guestbook.java
@@ -24,4 +24,12 @@ public class Guestbook extends BaseEntity {
     @Column(length = 50, nullable = false)
     private String writer;
 
+    public void changeTitle(String title){
+        this.title = title;
+    }
+
+    public void changeContent(String content){
+        this.content = content;
+    }
+
 }

--- a/guestbook/src/test/java/org/zerock/guestbook/repository/GuestbookRepositoryTests.java
+++ b/guestbook/src/test/java/org/zerock/guestbook/repository/GuestbookRepositoryTests.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.zerock.guestbook.entity.Guestbook;
 
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 @SpringBootTest
@@ -24,5 +25,19 @@ public class GuestbookRepositoryTests {
                     .build();
             System.out.println(guestbookRepository.save(guestbook));
         });
+    }
+
+    @Test
+    public void updateTest() {
+        Optional<Guestbook> result = guestbookRepository.findById(300L);
+
+        if(result.isPresent()){
+            Guestbook guestbook = result.get();
+
+            guestbook.changeTitle("Changed Title....");
+            guestbook.changeContent("Changed Content...");
+
+            guestbookRepository.save(guestbook);
+        }
     }
 }

--- a/guestbook/src/test/java/org/zerock/guestbook/repository/GuestbookRepositoryTests.java
+++ b/guestbook/src/test/java/org/zerock/guestbook/repository/GuestbookRepositoryTests.java
@@ -1,9 +1,16 @@
 package org.zerock.guestbook.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.zerock.guestbook.entity.Guestbook;
+import org.zerock.guestbook.entity.QGuestbook;
 
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -39,5 +46,53 @@ public class GuestbookRepositoryTests {
 
             guestbookRepository.save(guestbook);
         }
+    }
+
+    @Test
+    public void testQuery1() {
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+
+        QGuestbook qGuestbook = QGuestbook.guestbook;
+
+        String keyword = "1";
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        BooleanExpression expression = qGuestbook.title.contains(keyword);
+
+        builder.and(expression);
+
+        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+
+        result.stream().forEach(guestbook -> {
+            System.out.println(guestbook);
+        });
+    }
+
+    @Test
+    public void testQuery2() {
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+
+        QGuestbook qGuestbook = QGuestbook.guestbook;
+
+        String keyword = "1";
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        BooleanExpression exTitle =  qGuestbook.title.contains(keyword);
+
+        BooleanExpression exContent =  qGuestbook.content.contains(keyword);
+
+        BooleanExpression exAll = exTitle.or(exContent);
+
+        builder.and(exAll);
+
+        builder.and(qGuestbook.gno.gt(0L));
+
+        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+
+        result.stream().forEach(guestbook -> {
+            System.out.println(guestbook);
+        });
     }
 }

--- a/guestbook/src/test/java/org/zerock/guestbook/repository/GuestbookRepositoryTests.java
+++ b/guestbook/src/test/java/org/zerock/guestbook/repository/GuestbookRepositoryTests.java
@@ -1,0 +1,28 @@
+package org.zerock.guestbook.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.zerock.guestbook.entity.Guestbook;
+
+import java.util.stream.IntStream;
+
+@SpringBootTest
+public class GuestbookRepositoryTests {
+
+    @Autowired
+    private GuestbookRepository guestbookRepository;
+
+    @Test
+    public void insertDummies(){
+        IntStream.rangeClosed(1,300).forEach(i -> {
+
+            Guestbook guestbook = Guestbook.builder()
+                    .title("Title...." + i)
+                    .content("Content..." +i)
+                    .writer("user" + (i % 10))
+                    .build();
+            System.out.println(guestbookRepository.save(guestbook));
+        });
+    }
+}


### PR DESCRIPTION
Querydsl의 사용법을 익히기 위해 교재에서 나온 실습을 테스트해본다.
---
- 데이터 생성 테스트
- 데이터 수정 테스트
- 데이터 검색 테스트